### PR TITLE
Add command to clear Finance DB

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,13 @@
 import os
+import platform
+import signal
+import subprocess
 
 import click
 from dotenv import load_dotenv
-import os
-import signal
-import subprocess
-import click
-import platform
 
 
-from src.database.entrypoint import create_db
+from src.database.entrypoint import create_db, clear_database
 
 load_dotenv()
 
@@ -156,6 +154,16 @@ def cli_start_engine():
             click.echo("Connected to database via SQLAlchemy engine.")
     except Exception as e:
         click.echo(f"Failed to connect to database: {e}", err=True)
+
+
+@cli.command(name="clear-database")
+def cli_clear_database():
+    """Drop all tables from the Finance database."""
+    if click.confirm("Are you sure you want to clear the database?", default=False):
+        clear_database()
+        click.echo("Database cleared.")
+    else:
+        click.echo("Aborting database clear.")
 
 
 if __name__ == "__main__":

--- a/src/database/entrypoint.py
+++ b/src/database/entrypoint.py
@@ -38,3 +38,18 @@ def create_test_database():
         Base.metadata.create_all(bind=conn)
         metadata.schema = None  # reset back
     return engine
+
+
+def clear_database():
+    """Drop all tables in the Finance database."""
+    schema = "dbo"
+    username = os.getenv("POSTGRES_USERNAME")
+    password = os.getenv("POSTGRES_PASSWORD")
+    url = f"postgresql+psycopg2://{username}:{password}@localhost:5432/Finance"
+    engine = create_engine(url, echo=False)
+    with engine.begin() as conn:
+        conn.execute(text(f'SET search_path TO "{schema}"'))
+        metadata.schema = schema
+        Base.metadata.drop_all(bind=conn)
+        metadata.schema = None
+    return engine


### PR DESCRIPTION
## Summary
- add `clear_database` utility for dropping tables
- expose new `clear-database` CLI command using click

## Testing
- `pytest -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685863c1f604832bad6b056a385a6fe5