### PR TITLE
Add React frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.iml
 *.pyc
 *.env
+# Node
+client/node_modules/
+client/dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# SelfFinance
+
+This repository now includes a React frontend located in the `client` folder.
+
+## Running the React App
+
+1. Install Node dependencies:
+
+   ```bash
+   cd client
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+The application will be available at the URL printed by the Vite server (usually `http://localhost:5173`).

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Self Finance</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "self-finance-client",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Welcome to Self Finance</h1>
+      <p>React app is running!</p>
+    </div>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add React frontend using Vite under `client`
- document how to run the React app
- ignore node modules and build output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Could not connect to pypi due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c9bf52ba8832bb495cac60d9acd05