### PR TITLE
Add command to start React app

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,5 +149,12 @@ def cli_clear_database():
         click.echo("Aborting database clear.")
 
 
+@cli.command(name="start-app")
+def cli_start_app():
+    """Start the React development server."""
+    client_dir = os.path.join(os.path.dirname(__file__), "client")
+    subprocess.run(["npm", "run", "dev"], cwd=client_dir, check=True)
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## Summary
- provide a new `start-app` Click command to launch the React development server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_685ca19fce04832bbf3644c093cc0aac