### PR TITLE
Add CLI support for FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,28 @@ This repository now includes a React frontend located in the `client` folder.
    ```
 
 The application will be available at the URL printed by the Vite server (usually `http://localhost:5173`).
+
+## Running the FastAPI Backend
+
+1. Install Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the API server:
+
+   ```bash
+   uvicorn src.api.main:app --reload
+   ```
+
+The API will be available at `http://localhost:8000` by default.
+
+## Running Both Servers Together
+
+Use the provided Click command to launch the React frontend and FastAPI
+backend at the same time:
+
+```bash
+python main.py start-app
+```

--- a/main.py
+++ b/main.py
@@ -151,9 +151,22 @@ def cli_clear_database():
 
 @cli.command(name="start-app")
 def cli_start_app():
-    """Start the React development server."""
+    """Start both the React dev server and FastAPI backend."""
     client_dir = os.path.join(os.path.dirname(__file__), "client")
-    subprocess.run(["npm", "run", "dev"], cwd=client_dir, check=True)
+
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "src.api.main:app",
+        "--reload",
+    ])
+    react_proc = subprocess.Popen(["npm", "run", "dev"], cwd=client_dir)
+
+    try:
+        react_proc.wait()
+    finally:
+        api_proc.terminate()
+        react_proc.terminate()
+        api_proc.wait(timeout=5)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ black==25.1.0
 dash==2.16.1
 openpyxl==3.1.5
 pandera==0.24.0
+fastapi==0.110.1
+uvicorn==0.29.0

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, HTTPException
+import datetime as dt
+from src.managers.source_manager.entrypoint import create_sourcedata_service
+from src.managers.source_manager.domain import GroceriesExpense
+
+app = FastAPI()
+service = create_sourcedata_service()
+
+@app.get("/")
+def read_root():
+    return {"message": "SelfFinance API"}
+
+@app.post("/groceries")
+def add_groceries(expense: GroceriesExpense):
+    service.insert_groceries(groceries=expense)
+    return {"status": "ok"}
+
+@app.get("/groceries/{date}")
+def get_groceries(date: str):
+    try:
+        dt_date = dt.datetime.fromisoformat(date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid date format") from exc
+    groceries = service.get_groceries_by_date(date=dt_date)
+    if not groceries:
+        raise HTTPException(status_code=404, detail="Groceries not found")
+    return groceries


### PR DESCRIPTION
## Summary
- update `start-app` click command to start both React and FastAPI servers
- document combined server command in README
- add trailing newline in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find pandas due to network restrictions)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_685ca4583bc0832ba295b21210148a43