### PR TITLE
Fix path for React entry file

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="app/src/index.jsx"></script>
+    <script type="module" src="/src/index.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix path to the React entry file in `app/index.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68616ba362e8832bb6718ccb902ea851