### PR TITLE
Add login table

### DIFF
--- a/src/database/database.py
+++ b/src/database/database.py
@@ -174,3 +174,12 @@ class VenmoTable(Base):
     Date = Column("Date", DateTime, unique=False, nullable=False)
     Amount = Column("Amount", Float, unique=False, nullable=False)
     Description = Column("Description", Unicode(100), unique=False, nullable=True)
+
+
+class LoginTable(Base):
+    __tablename__ = "Login"
+    __table_args__ = (PrimaryKeyConstraint("ID", name="PK_Login_ID"),)
+
+    ID = Column("ID", Integer, Identity(start=1), nullable=False)
+    Username = Column("Username", Unicode(50), nullable=False, unique=True)
+    Password = Column("Password", Unicode(100), nullable=False, unique=False)

--- a/src/managers/source_manager/domain.py
+++ b/src/managers/source_manager/domain.py
@@ -117,3 +117,10 @@ class SinkingFundType(BaseModel):
 
     fund_type: str
     total: float
+
+
+class Login(BaseModel):
+    """Domain model for :class:`LoginTable`."""
+
+    username: str
+    password: str

--- a/src/managers/source_manager/mappers.py
+++ b/src/managers/source_manager/mappers.py
@@ -14,6 +14,7 @@ from src.database.database import (
     SinkingFundTypeTable,
     SubscriptionTable,
     VenmoTable,
+    LoginTable,
 )
 from src.managers.source_manager.domain import (
     ApartmentExpense,
@@ -31,6 +32,7 @@ from src.managers.source_manager.domain import (
     SinkingFundType,
     SubscriptionExpense,
     Venmo,
+    Login,
 )
 
 
@@ -158,7 +160,9 @@ def map_entity_to_domain_eating_out_expense(record: EatingOutTable) -> EatingOut
     )
 
 
-def map_domain_to_entity_eating_out_expense(expense: EatingOutExpense) -> EatingOutTable:
+def map_domain_to_entity_eating_out_expense(
+    expense: EatingOutExpense,
+) -> EatingOutTable:
     """
     Convert a domain ``EatingOutExpense`` into an ``EatingOutTable`` row.
 
@@ -327,7 +331,9 @@ def map_entity_to_domain_investment_type(record: InvestmentTypeTable) -> Investm
     )
 
 
-def map_domain_to_entity_investment_type(investment_type: InvestmentType) -> InvestmentTypeTable:
+def map_domain_to_entity_investment_type(
+    investment_type: InvestmentType,
+) -> InvestmentTypeTable:
     """
     Convert a domain ``InvestmentType`` into an ``InvestmentTypeTable`` row.
 
@@ -442,7 +448,9 @@ def map_domain_to_entity_sinking_fund(fund: SinkingFund) -> SinkingFundTable:
     )
 
 
-def map_entity_to_domain_sinking_fund_type(record: SinkingFundTypeTable) -> SinkingFundType:
+def map_entity_to_domain_sinking_fund_type(
+    record: SinkingFundTypeTable,
+) -> SinkingFundType:
     """
     Convert a ``SinkingFundTypeTable`` row into a ``SinkingFundType`` domain model.
 
@@ -458,7 +466,9 @@ def map_entity_to_domain_sinking_fund_type(record: SinkingFundTypeTable) -> Sink
     )
 
 
-def map_domain_to_entity_sinking_fund_type(fund_type: SinkingFundType) -> SinkingFundTypeTable:
+def map_domain_to_entity_sinking_fund_type(
+    fund_type: SinkingFundType,
+) -> SinkingFundTypeTable:
     """
     Convert a ``SinkingFundType`` domain object into a ``SinkingFundTypeTable`` row.
 
@@ -474,7 +484,9 @@ def map_domain_to_entity_sinking_fund_type(fund_type: SinkingFundType) -> Sinkin
     )
 
 
-def map_entity_to_domain_subscription_expense(record: SubscriptionTable) -> SubscriptionExpense:
+def map_entity_to_domain_subscription_expense(
+    record: SubscriptionTable,
+) -> SubscriptionExpense:
     """
     Convert a ``SubscriptionTable`` row into a domain ``SubscriptionExpense``.
 
@@ -491,7 +503,9 @@ def map_entity_to_domain_subscription_expense(record: SubscriptionTable) -> Subs
     )
 
 
-def map_domain_to_entity_subscription_expense(expense: SubscriptionExpense) -> SubscriptionTable:
+def map_domain_to_entity_subscription_expense(
+    expense: SubscriptionExpense,
+) -> SubscriptionTable:
     """
     Convert a domain ``SubscriptionExpense`` into a ``SubscriptionTable`` record.
 
@@ -539,4 +553,22 @@ def map_domain_to_entity_venmo(venmo: Venmo) -> VenmoTable:
         Date=venmo.date,
         Amount=venmo.amount,
         Description=venmo.description,
+    )
+
+
+def map_entity_to_domain_login(record: LoginTable) -> Login:
+    """Convert a ``LoginTable`` row into a ``Login`` domain object."""
+
+    return Login(
+        username=record.Username,
+        password=record.Password,
+    )
+
+
+def map_domain_to_entity_login(login: Login) -> LoginTable:
+    """Convert a ``Login`` domain object into a ``LoginTable`` row."""
+
+    return LoginTable(
+        Username=login.username,
+        Password=login.password,
     )

--- a/src/managers/source_manager/service.py
+++ b/src/managers/source_manager/service.py
@@ -16,6 +16,7 @@ from src.managers.source_manager.domain import (
     SinkingFundType,
     SubscriptionExpense,
     Venmo,
+    Login,
 )
 from src.managers.uow.sourcedata_uow import SourceDataUnitOfWork
 
@@ -79,9 +80,7 @@ class SourceDataService:
 
     def insert_investment_type(self, investment_type: InvestmentType):
         with self._source_data_uow as uow:
-            uow.source_data_repo.insert_investment_type(
-                investment_type=investment_type
-            )
+            uow.source_data_repo.insert_investment_type(investment_type=investment_type)
             uow.commit()
 
     def insert_misc_expense(self, expense: MiscExpense):
@@ -127,3 +126,17 @@ class SourceDataService:
         with self._source_data_uow as uow:
             groceries = uow.source_data_repo.get_groceries_by_date(date=date)
         return groceries
+
+    def insert_login(self, login: Login) -> None:
+        """Insert a ``Login`` record into the database."""
+
+        with self._source_data_uow as uow:
+            uow.source_data_repo.insert_login(login=login)
+            uow.commit()
+
+    def get_login_by_username(self, username: str) -> Login | None:
+        """Retrieve a login by username if present."""
+
+        with self._source_data_uow as uow:
+            login = uow.source_data_repo.get_login_by_username(username=username)
+        return login

--- a/src/repositories/source_data_repo.py
+++ b/src/repositories/source_data_repo.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from src.database.database import (
     GroceriesTable,
+    LoginTable,
 )
 from src.managers.source_manager.domain import (
     ApartmentExpense,
@@ -21,6 +22,7 @@ from src.managers.source_manager.domain import (
     SinkingFundType,
     SubscriptionExpense,
     Venmo,
+    Login,
 )
 from src.managers.source_manager.mappers import (
     map_domain_to_entity_apartment_spending,
@@ -38,6 +40,8 @@ from src.managers.source_manager.mappers import (
     map_domain_to_entity_sinking_fund_type,
     map_domain_to_entity_subscription_expense,
     map_domain_to_entity_venmo,
+    map_domain_to_entity_login,
+    map_entity_to_domain_login,
     map_entity_to_domain_groceries,
 )
 
@@ -221,3 +225,21 @@ class SourceDataRepository:
         if record:
             groceries = map_entity_to_domain_groceries(record=record)
             return groceries
+
+    def insert_login(self, login: Login) -> None:
+        """Insert a login record into the database."""
+
+        record = map_domain_to_entity_login(login)
+        self._session.add(record)
+
+    def get_login_by_username(self, username: str) -> Login | None:
+        """Retrieve a login by username if present."""
+
+        record = (
+            self._session.query(LoginTable)
+            .where(LoginTable.Username == username)
+            .first()
+        )
+        if record:
+            return map_entity_to_domain_login(record=record)
+        return None

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,15 @@
+import datetime as dt
+
+from src.managers.source_manager.domain import Login
+from tests.service import create_test_sourcedata_service
+
+
+class TestLogin:
+    def test_insert_and_get_login(self):
+        service = create_test_sourcedata_service()
+        login = Login(username="user1", password="pass123")
+        service.insert_login(login=login)
+        retrieved = service.get_login_by_username(username="user1")
+        assert retrieved is not None
+        assert retrieved.username == "user1"
+        assert retrieved.password == "pass123"


### PR DESCRIPTION
## Summary
- support login data via new table, domain model, repository and service methods
- map login entities
- test login insert/retrieval

## Testing
- `PYTHONPATH=. pytest -q tests/test_login.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68633007daf4832b866532acd8ea0793