### PR TITLE
Hash login passwords

### DIFF
--- a/src/managers/source_manager/mappers.py
+++ b/src/managers/source_manager/mappers.py
@@ -34,6 +34,7 @@ from src.managers.source_manager.domain import (
     Venmo,
     Login,
 )
+from src.security import hash_password
 
 
 def map_entity_to_domain_apartment_spending(
@@ -570,5 +571,5 @@ def map_domain_to_entity_login(login: Login) -> LoginTable:
 
     return LoginTable(
         Username=login.username,
-        Password=login.password,
+        Password=hash_password(login.password),
     )

--- a/src/security.py
+++ b/src/security.py
@@ -1,0 +1,18 @@
+import os
+import base64
+import hashlib
+
+
+def hash_password(password: str) -> str:
+    """Hash ``password`` using PBKDF2 with SHA-256."""
+    salt = os.urandom(16)
+    hashed = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+    return base64.b64encode(salt + hashed).decode("utf-8")
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Return ``True`` if ``password`` matches ``hashed_password``."""
+    decoded = base64.b64decode(hashed_password.encode("utf-8"))
+    salt, stored_hash = decoded[:16], decoded[16:]
+    new_hash = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+    return hashlib.compare_digest(new_hash, stored_hash)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,6 +2,7 @@ import datetime as dt
 
 from src.managers.source_manager.domain import Login
 from tests.service import create_test_sourcedata_service
+from src.security import verify_password
 
 
 class TestLogin:
@@ -12,4 +13,4 @@ class TestLogin:
         retrieved = service.get_login_by_username(username="user1")
         assert retrieved is not None
         assert retrieved.username == "user1"
-        assert retrieved.password == "pass123"
+        assert verify_password("pass123", retrieved.password)


### PR DESCRIPTION
## Summary
- add password hashing utilities
- store hashed passwords when creating `Login` records
- check hashed password in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6863388ce6f0832bb4e7aeed17a7d97d